### PR TITLE
Hotfix for Exisiting Maven Project Import in Eclipse on master branch.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,5 @@
 *.xcf binary
 *.dll binary
 *.jar binary
+
+.gitignore merge=ours

--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,5 @@ build/
 .classpath
 .project
 *.orig
+.checkstyle
 # End from pc rando

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,8 @@
             <id>validate</id>
             <phase>validate</phase>
             <configuration>
+              <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+              <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
               <!-- dear god, the kludge. http://stackoverflow.com/a/15004792 -->
               <configLocation>${project.build.resources[0].directory}/checkstyle.xml</configLocation>
               <encoding>UTF-8</encoding>


### PR DESCRIPTION
Sounded like you already ran into this and fixed it too. Sorry I did not test the latest in Eclipse... IntelliJ FTW.
