### PR TITLE
Hotfix for Exisiting Maven Project Import in Eclipse on Develop branch.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,5 @@
 *.xcf binary
 *.dll binary
 *.jar binary
+
+.gitignore merge=ours

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,8 @@
             <id>validate</id>
             <phase>validate</phase>
             <configuration>
+              <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+              <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
               <!-- dear god, the kludge. http://stackoverflow.com/a/15004792 -->
               <configLocation>${project.build.resources[0].directory}/checkstyle.xml</configLocation>
               <encoding>UTF-8</encoding>


### PR DESCRIPTION
See [existing pull request for master branch.](https://github.com/Hornswaggler/fuzzy-octo-shame/pull/9)
